### PR TITLE
helyOS Dashboard - Agent offline, columns grey

### DIFF
--- a/helyos_dashboard/src/app/layout/agent-assignments/agent-assignments.component.html
+++ b/helyos_dashboard/src/app/layout/agent-assignments/agent-assignments.component.html
@@ -146,7 +146,7 @@
 
     <div class="row">
       <fieldset class="form-group col-xl-12">
-        <label for="data"> Assignment order </label>
+        <label for="data"> Assignment data </label>
         <textarea id="data" rows="4" class="form-control" [(ngModel)]="selectedItem.data" name="data"></textarea>
       </fieldset>
     </div>

--- a/helyos_dashboard/src/app/layout/agent-assistants/agent-assistants.component.html
+++ b/helyos_dashboard/src/app/layout/agent-assistants/agent-assistants.component.html
@@ -55,15 +55,26 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
+              'disabled': item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
           </td>
-          <td [ngClass]="{ 'bg-danger': item.updtPerSec > 5 }" title="Optimal: < 2 Hz">
+          <td
+            [ngClass]="{
+              'bg-danger': item.updtPerSec > 5,
+              'disabled': item.connectionStatus === 'offline',
+            }"
+            title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
           </td>
           <td>{{ item.yardId }}</td>
-          <td>{{ item.status }}</td>
+          <td
+            [ngClass]="{
+              'disabled': item.connectionStatus === 'offline',
+            }">
+            {{ item.status }}
+          </td>
         </tr>
       </tbody>
     </table>

--- a/helyos_dashboard/src/app/layout/agent-assistants/agent-assistants.component.html
+++ b/helyos_dashboard/src/app/layout/agent-assistants/agent-assistants.component.html
@@ -55,7 +55,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -63,7 +63,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5,
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
@@ -71,7 +71,7 @@
           <td>{{ item.yardId }}</td>
           <td
             [ngClass]="{
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }">
             {{ item.status }}
           </td>

--- a/helyos_dashboard/src/app/layout/agent-chargeStations/agent-chargeStations.component.html
+++ b/helyos_dashboard/src/app/layout/agent-chargeStations/agent-chargeStations.component.html
@@ -54,7 +54,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30,
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -62,7 +62,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5,
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
@@ -70,7 +70,7 @@
           <td>{{ item.yardId }}</td>
           <td
             [ngClass]="{
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }">
             {{ item.status }}
           </td>

--- a/helyos_dashboard/src/app/layout/agent-chargeStations/agent-chargeStations.component.html
+++ b/helyos_dashboard/src/app/layout/agent-chargeStations/agent-chargeStations.component.html
@@ -51,14 +51,29 @@
           <td>{{ item.x }}</td>
           <td>{{ item.y }}</td>
 
-          <td [ngClass]="{ 'bg-danger': item.msgPerSec > 30 }" title="Optimal: 10Hz.">
+          <td
+            [ngClass]="{
+              'bg-danger': item.msgPerSec > 30,
+              'disabled': item.connectionStatus === 'offline',
+            }"
+            title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
           </td>
-          <td [ngClass]="{ 'bg-danger': item.updtPerSec > 5 }" title="Optimal: < 2 Hz">
+          <td
+            [ngClass]="{
+              'bg-danger': item.updtPerSec > 5,
+              'disabled': item.connectionStatus === 'offline',
+            }"
+            title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
           </td>
           <td>{{ item.yardId }}</td>
-          <td>{{ item.status }}</td>
+          <td
+            [ngClass]="{
+              'disabled': item.connectionStatus === 'offline',
+            }">
+            {{ item.status }}
+          </td>
         </tr>
       </tbody>
     </table>

--- a/helyos_dashboard/src/app/layout/agent-regist/agent-regist.component.html
+++ b/helyos_dashboard/src/app/layout/agent-regist/agent-regist.component.html
@@ -58,6 +58,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
+              'disabled': item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -65,12 +66,18 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5 && item.connectionStatus === 'online',
+              'disabled': item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
           </td>
           <td>{{ item.yardId }}</td>
-          <td>{{ item.status }}</td>
+          <td
+            [ngClass]="{
+              'disabled': item.connectionStatus === 'offline',
+            }">
+            {{ item.status }}
+          </td>
           <td>{{ item.connectionStatus }}</td>
         </tr>
       </tbody>

--- a/helyos_dashboard/src/app/layout/agent-regist/agent-regist.component.html
+++ b/helyos_dashboard/src/app/layout/agent-regist/agent-regist.component.html
@@ -58,7 +58,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -66,7 +66,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5 && item.connectionStatus === 'online',
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
@@ -74,7 +74,7 @@
           <td>{{ item.yardId }}</td>
           <td
             [ngClass]="{
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }">
             {{ item.status }}
           </td>

--- a/helyos_dashboard/src/app/layout/agent-tools/agent-tools.component.html
+++ b/helyos_dashboard/src/app/layout/agent-tools/agent-tools.component.html
@@ -58,6 +58,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
+              'disabled': item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -65,12 +66,18 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5 && item.connectionStatus === 'online',
+              'disabled': item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
           </td>
           <td>{{ item.yardId }}</td>
-          <td>{{ item.status }}</td>
+          <td
+            [ngClass]="{
+              'disabled': item.connectionStatus === 'offline',
+            }">
+            {{ item.status }}
+          </td>
         </tr>
       </tbody>
     </table>

--- a/helyos_dashboard/src/app/layout/agent-tools/agent-tools.component.html
+++ b/helyos_dashboard/src/app/layout/agent-tools/agent-tools.component.html
@@ -58,7 +58,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -66,7 +66,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5 && item.connectionStatus === 'online',
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
@@ -74,7 +74,7 @@
           <td>{{ item.yardId }}</td>
           <td
             [ngClass]="{
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }">
             {{ item.status }}
           </td>

--- a/helyos_dashboard/src/app/layout/agent-vehicles/agent-vehicles.component.html
+++ b/helyos_dashboard/src/app/layout/agent-vehicles/agent-vehicles.component.html
@@ -56,7 +56,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -64,7 +64,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5 && item.connectionStatus === 'online',
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
@@ -72,7 +72,7 @@
           <td>{{ item.yardId }}</td>
           <td
             [ngClass]="{
-              'disabled': item.connectionStatus === 'offline',
+              disabled: item.connectionStatus === 'offline',
             }">
             {{ item.status }}
           </td>

--- a/helyos_dashboard/src/app/layout/agent-vehicles/agent-vehicles.component.html
+++ b/helyos_dashboard/src/app/layout/agent-vehicles/agent-vehicles.component.html
@@ -56,6 +56,7 @@
           <td
             [ngClass]="{
               'bg-danger': item.msgPerSec > 30 && item.connectionStatus === 'online',
+              'disabled': item.connectionStatus === 'offline',
             }"
             title="Optimal: 10Hz.">
             {{ item.msgPerSec | number: '1.2-2' }}
@@ -63,12 +64,18 @@
           <td
             [ngClass]="{
               'bg-danger': item.updtPerSec > 5 && item.connectionStatus === 'online',
+              'disabled': item.connectionStatus === 'offline',
             }"
             title="Optimal: < 2 Hz">
             {{ item.updtPerSec | number: '1.2-2' }}
           </td>
           <td>{{ item.yardId }}</td>
-          <td>{{ item.status }}</td>
+          <td
+            [ngClass]="{
+              'disabled': item.connectionStatus === 'offline',
+            }">
+            {{ item.status }}
+          </td>
         </tr>
       </tbody>
     </table>

--- a/helyos_dashboard/src/app/layout/components/sidebar/sidebar.component.html
+++ b/helyos_dashboard/src/app/layout/components/sidebar/sidebar.component.html
@@ -142,16 +142,16 @@
       <i class="mx-2 fa-solid fa-fw">
         <img src="assets/icons/assignment-svgrepo-501100.svg" class="x-svgrepo-icon" alt="icon" />
         <span itemprop="creator" itemscope="" itemtype="http://schema.org/Organization">
-          <meta itemprop="name" content="SVG Repo">
+          <meta itemprop="name" content="SVG Repo" />
         </span>
-        <meta itemprop="author" content="SVG Repo">
-        <meta itemprop="name" content="Assignment SVG Vector Icon">
-        <meta itemprop="contentUrl" content="https://www.svgrepo.com/show/501100/assignment.svg">
-        <meta itemprop="creditText" content="SVG Repo">
-        <meta itemprop="copyrightNotice" content="MIT">
-        <meta itemprop="license" content="https://www.svgrepo.com/page/licensing/#MIT">
-        <meta itemprop="acquireLicensePage" content="https://www.svgrepo.com/page/licensing/#MIT">
-        <meta itemprop="url" content="https://www.svgrepo.com/svg/501100/assignment">
+        <meta itemprop="author" content="SVG Repo" />
+        <meta itemprop="name" content="Assignment SVG Vector Icon" />
+        <meta itemprop="contentUrl" content="https://www.svgrepo.com/show/501100/assignment.svg" />
+        <meta itemprop="creditText" content="SVG Repo" />
+        <meta itemprop="copyrightNotice" content="MIT" />
+        <meta itemprop="license" content="https://www.svgrepo.com/page/licensing/#MIT" />
+        <meta itemprop="acquireLicensePage" content="https://www.svgrepo.com/page/licensing/#MIT" />
+        <meta itemprop="url" content="https://www.svgrepo.com/svg/501100/assignment" />
       </i>
       <span>{{ 'Agent Assignments' | translate }}</span>
     </a>

--- a/helyos_dashboard/src/styles/app.scss
+++ b/helyos_dashboard/src/styles/app.scss
@@ -56,3 +56,7 @@ tr {
   cursor: pointer;
   width: 300px;
 }
+
+.table .disabled {
+  color: grey;
+}


### PR DESCRIPTION
- status, msg/sec and db updts/sec are now grey when the agent's `connectionStatus` is `offline`.
- Changed the label `Assignment order` to `Assignment data` in the `Agent Assignments` view.

Resolves [helyOSFramework/helyos_core#48](https://github.com/helyOSFramework/helyos_core/issues/48)