### PR TITLE
Feat: Set RabbitMQ virtual host in helyOS core

### DIFF
--- a/helyos_server/src/services/message_broker/rabbitMQ_access_layer.js
+++ b/helyos_server/src/services/message_broker/rabbitMQ_access_layer.js
@@ -12,6 +12,7 @@ const RBMQ_API_PORT= process.env.RBMQ_API_PORT || 15672;
 const RBMQ_CNAME = process.env.RBMQ_CNAME || RBMQ_HOST;
 const RBMQ_ADMIN_USERNAME= process.env.RBMQ_ADMIN_USERNAME || 'guest';
 const RBMQ_ADMIN_PASSWORD= process.env.RBMQ_ADMIN_PASSWORD || 'guest';
+const RBMQ_VHOST = process.env.RBMQ_VHOST || '%2F';
 
 const RBMQ_SSL = (process.env.RBMQ_SSL || "False") === "True";
 const RBMQ_API_SSL = (process.env.RBMQ_API_SSL || process.env.RBMQ_SSL || "False") === "True";
@@ -31,7 +32,7 @@ const create_rbmq_admin = (username, password, tags) =>
         .set( {'content-type': 'application/json'  }).ca(RBMQ_CERTIFICATE)
         .auth('guest', 'guest')
         .then(() => requestXHTTP
-                    .put(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/permissions/%2F/${username}`)
+                    .put(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/permissions/${RBMQ_VHOST}/${username}`)
                     .send({"configure":".*","write":".*","read":".*"})
                     .set( {'content-type': 'application/json'  }).ca(RBMQ_CERTIFICATE)
                     .auth('guest', 'guest'))
@@ -64,7 +65,7 @@ const removeUser = (username) =>  !username? Promise.resolve(null) :
 
 const add_rbmq_user_vhost = (username) =>  !username? Promise.resolve(null) :
         requestXHTTP
-        .put(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/permissions/%2F/${username}`)
+        .put(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/permissions/${RBMQ_VHOST}/${username}`)
         .send({"configure":".*","write":".*","read":".*"})
         .set( {'content-type': 'application/json'  }).ca(RBMQ_CERTIFICATE)
         .auth(RBMQ_ADMIN_USERNAME, RBMQ_ADMIN_PASSWORD)
@@ -101,7 +102,7 @@ const deleteConnections = (username) =>  {
 const guestPermissions = `(amq\.gen.*|${ANONYMOUS_EXCHANGE})`;
 const update_guest_account_permissions = (username) => !username? Promise.resolve(null) :
         requestXHTTP
-        .put(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/permissions/%2F/${username}`)
+        .put(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/permissions/${RBMQ_VHOST}/${username}`)
         .send({"configure":`^${guestPermissions}`,"write":guestPermissions,"read":guestPermissions})
         .set( {'content-type': 'application/json'  }).ca(RBMQ_CERTIFICATE)
         .auth(RBMQ_ADMIN_USERNAME, RBMQ_ADMIN_PASSWORD)
@@ -112,7 +113,7 @@ const update_guest_account_permissions = (username) => !username? Promise.resolv
 
 const getQueueInfo = (queueName) => {
         return requestXHTTP
-        .get(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/queues/%2F/${queueName}`)
+        .get(`${API_PROTOCOL}://${RBMQ_HOST}:${RBMQ_API_PORT}/api/queues/${RBMQ_VHOST}/${queueName}`)
         .set( {'content-type': 'application/json'  }).ca(RBMQ_CERTIFICATE)
         .auth(RBMQ_ADMIN_USERNAME, RBMQ_ADMIN_PASSWORD)
         .then(r => r.body);

--- a/helyos_server/src/services/message_broker/rabbitMQ_services.js
+++ b/helyos_server/src/services/message_broker/rabbitMQ_services.js
@@ -31,6 +31,7 @@ const CHECK_IN_QUEUE = process.env.CHECK_IN_QUEUE ||         'agent_checkin_queu
 const AGENT_UPDATE_QUEUE = process.env.AGENT_UPDATE_QUEUE || 'agent_update_queue';
 const AGENT_VISUALIZATION_QUEUE = process.env.AGENT_VISUALIZATION_QUEUE || 'agent_visualization_queue';
 const YARD_VISUALIZATION_QUEUE = process.env.YARD_VISUALIZATION_QUEUE || 'yard_visualization_queue';
+const RBMQ_VHOST = process.env.RBMQ_VHOST || '%2F';
 
 const AGENT_STATE_QUEUE = process.env.AGENT_STATE_QUEUE || 'agent_state_queue';
 const AGENT_MISSION_QUEUE = process.env.AGENT_MISSION_QUEUE || 'agent_mission_queue';
@@ -63,6 +64,15 @@ try {
     console.warn('Private and/or public key not defined');
 }
 
+const urlObj = (username=RBMQ_USERNAME, password=RBMQ_PASSWORD) => ({
+        hostname:  RBMQ_HOST,
+        port: RBMQ_PORT,
+        username: username,
+        password: password,
+        protocol: RBMQ_PROTOCOL,
+        vhost: username==='guest'? '%2F':RBMQ_VHOST
+        // vhost: `%2F${RBMQ_VHOST}`
+    });
 
 
 function verifyMessageSignature(message, publicKey, signature) {
@@ -76,13 +86,6 @@ function verifyMessageSignature(message, publicKey, signature) {
     return verifier.verify(pubkeyPadding, signature, 'hex');
 }
 
-const urlObj = (username=RBMQ_USERNAME, password=RBMQ_PASSWORD) => ({
-        hostname:  RBMQ_HOST,
-        port: RBMQ_PORT,
-        username: username,
-        password: password,
-        protocol: RBMQ_PROTOCOL
-    });
 
 const connect = (username, password) => rbmqAccessLayer.connect(urlObj(username, password), sslOptions);
 const disconnect = async () =>  {   

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -174,6 +174,7 @@ beforeAll(async () => {
 
 
       agentSimulatorContainer2 = await new GenericContainer('helyosframework/helyos_agent_slim_simulator:0.8.2')
+      .withPlatform("linux/amd64")
       .withEnvironment({
         'UUID': 'Bb34069fc5-fdgs-434b-b87e-f19c5435113',
         'ASSIGNMENT_FORMAT': 'trajectory',


### PR DESCRIPTION
Use environment variable RBMQ_VHOST to set the virtual host for helyOS core.
