### PR TITLE
helyos_dashboard - Improve Visual Data Representation in Mission's Exported YML

### DIFF
--- a/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
+++ b/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
@@ -51,24 +51,25 @@ export const exportToYML = async (wpTypeMethods: WORKPROCESS_TYPE, wpServPlanMet
   const workprocessPlans: H_WorkProcessServicePlan[] = await wpServPlanMethods.list({});
   const jsonIndent = 2
 
+  const missions = {};
   const dataJSON = {
     'version': '2.0',
-    'missions': {},
+    'missions': missions,
   };
   workprocessTypes.forEach((wpType) => {
 
     // parse properites of work_process_type into missions
-    dataJSON['missions'][wpType.name] = {};
+    missions[wpType.name] = {};
     for (const key in wpType) {
       if (Object.prototype.hasOwnProperty.call(WorkProcessTypeTableToYmlMap, key) && Object.prototype.hasOwnProperty.call(wpType, key)) {
         if (key === "settings" || key === "dispatchOrder") {
           // JSON.stringify() is used to preserve list brackets
           if (wpType[key] !== null) {
-            dataJSON['missions'][wpType.name][WorkProcessTypeTableToYmlMap[key]] = JSON.stringify(wpType[key], null, jsonIndent);
+            missions[wpType.name][WorkProcessTypeTableToYmlMap[key]] = JSON.stringify(wpType[key], null, jsonIndent);
           }
 
         } else {
-          dataJSON['missions'][wpType.name][WorkProcessTypeTableToYmlMap[key]] = wpType[key];
+          missions[wpType.name][WorkProcessTypeTableToYmlMap[key]] = wpType[key];
         }
       }
     }
@@ -98,7 +99,7 @@ export const exportToYML = async (wpTypeMethods: WORKPROCESS_TYPE, wpServPlanMet
     });
 
     if (formatedSteps.length > 0) {
-      dataJSON.missions[wpType.name]['recipe'] = {
+      missions[wpType.name]['recipe'] = {
         'steps': formatedSteps,
       };
     }

--- a/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
+++ b/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
@@ -108,6 +108,7 @@ export const exportToYML = async (wpTypeMethods: WORKPROCESS_TYPE, wpServPlanMet
   let ymlData = yaml.dump(dataJSON)
   ymlData = ymlData
     .replace(/(\n\s{2}\w+:)/g, '\n\n$1') // 2 line spaces before mission name at 2 spaces indentation
+    .replace(/(\n\s+- step:)/g, '\n$1'); // 1 line space before each step
   return Promise.resolve(ymlData);
 
 };

--- a/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
+++ b/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
@@ -49,6 +49,7 @@ export const exportToYML = async (wpTypeMethods: WORKPROCESS_TYPE, wpServPlanMet
   // Template JSON to populate data from tables
   const workprocessTypes: H_WorkProcessType[] = await wpTypeMethods.list({});
   const workprocessPlans: H_WorkProcessServicePlan[] = await wpServPlanMethods.list({});
+  const jsonIndent = 2
 
   const dataJSON = {
     'version': '2.0',
@@ -63,7 +64,7 @@ export const exportToYML = async (wpTypeMethods: WORKPROCESS_TYPE, wpServPlanMet
         if (key === "settings" || key === "dispatchOrder") {
           // JSON.stringify() is used to preserve list brackets
           if (wpType[key] !== null) {
-            dataJSON['missions'][wpType.name][WorkProcessTypeTableToYmlMap[key]] = JSON.stringify(wpType[key]);
+            dataJSON['missions'][wpType.name][WorkProcessTypeTableToYmlMap[key]] = JSON.stringify(wpType[key], null, jsonIndent);
           }
 
         } else {
@@ -80,7 +81,7 @@ export const exportToYML = async (wpTypeMethods: WORKPROCESS_TYPE, wpServPlanMet
         if (Object.prototype.hasOwnProperty.call(WorkProcessServicePlanTableToYmlMap, key) && Object.prototype.hasOwnProperty.call(wpStep, key)) {
           if (key === "dependsOnSteps") {  // JSON.stringify() is used to preserve list brackets
             if (wpStep[key] != null) {
-              formatedStep[WorkProcessServicePlanTableToYmlMap[key]] = JSON.stringify(wpStep[key]);
+              formatedStep[WorkProcessServicePlanTableToYmlMap[key]] = JSON.stringify(wpStep[key], null, jsonIndent);
             }
           } else {
             formatedStep[WorkProcessServicePlanTableToYmlMap[key]] = wpStep[key];

--- a/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
+++ b/helyos_dashboard/src/app/layout/work-processes/read_config_yml.ts
@@ -105,7 +105,9 @@ export const exportToYML = async (wpTypeMethods: WORKPROCESS_TYPE, wpServPlanMet
   });
 
   // convert JSON to yml
-  const ymlData = yaml.dump(dataJSON);
+  let ymlData = yaml.dump(dataJSON)
+  ymlData = ymlData
+    .replace(/(\n\s{2}\w+:)/g, '\n\n$1') // 2 line spaces before mission name at 2 spaces indentation
   return Promise.resolve(ymlData);
 
 };


### PR DESCRIPTION
- fix json representation in mission's settings using 2 space indentation

used regex to
- add 2 new line spacing before each mission name
- add 1 new line spacing before each step

Resolves [helyOSFramework/helyos_core#67](https://github.com/helyOSFramework/helyos_core/issues/67)