### PR TITLE
Fixing empty failure policy

### DIFF
--- a/helyos_server/src/event_handlers/database_event_handlers/assignment_db_events_handler.ts
+++ b/helyos_server/src/event_handlers/database_event_handlers/assignment_db_events_handler.ts
@@ -109,7 +109,7 @@ async function processAssignmentEvents(channel: string, payload: Assignment): Pr
           const assignmentFallbackMission = payload.fallback_mission;
 
           const onAssignmentFailure =
-            assignmentFailureAction && assignmentFailureAction !== ON_ASSIGNMENT_FAILURE_ACTIONS.DEFAULT
+            assignmentFailureAction && (assignmentFailureAction !== ON_ASSIGNMENT_FAILURE_ACTIONS.DEFAULT)
               ? assignmentFailureAction
               : defaultFailureAction;
 

--- a/helyos_server/src/event_handlers/rabbitmq_event_handlers/database_request_handler.ts
+++ b/helyos_server/src/event_handlers/rabbitmq_event_handlers/database_request_handler.ts
@@ -110,7 +110,16 @@ async function queryDataBase(uuid: string, objMsg: ObjMsg, msgProps: MsgProps): 
                 let conditions = objMsg.body['conditions'] || {deleted_at: null};
                 conditions = {deleted_at: null, ...conditions};
                 response = await databaseServices.map_objects.select(conditions);
-                break;             
+                break;            
+                
+            case 'missionsById':
+                if (objMsg.body['conditions']){
+                    const ms_id = objMsg.body.conditions.id || objMsg.body.conditions.mission_id;
+                    response = await databaseServices.work_processes.get_byId(ms_id);
+                } else {
+                    throw Error('Please include work_process_id (mission_id) in conditions. For example: {"id" : 1 }');
+                }
+                break;            
         }
 
         switch (objMsg.body['mutation']) {

--- a/helyos_server/src/modules/microservice_orchestration.ts
+++ b/helyos_server/src/modules/microservice_orchestration.ts
@@ -311,7 +311,7 @@ async function prepareServicesPipelineForWorkProcess(partialWorkProcess: Partial
     const recipe = await databaseServices.work_process_type.get('name', workProcess['work_process_type_name']).then(r => r.length ? r[0] : {});
 
     // Behaviour upon failure
-    if (workProcess.on_assignment_failure == ON_ASSIGNMENT_FAILURE_ACTIONS.DEFAULT) {
+    if (workProcess.on_assignment_failure == ON_ASSIGNMENT_FAILURE_ACTIONS.DEFAULT || workProcess.on_assignment_failure == null) {
         await databaseServices.work_processes.update_byId(workProcess.id, { on_assignment_failure: recipe.on_assignment_failure });
     }
     // Mission after failure


### PR DESCRIPTION
It is possible to create a work process with a `null` on_assignment_failure. This should be in the future restricted by the database. By now, the empty on_assignment_failure policy should be handled as the "DEFAULT" recipe policy.