### PR TITLE
show context.orchestration json in 'Dispatched Services' tab of helyos dashboard

### DIFF
--- a/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.html
+++ b/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.html
@@ -107,7 +107,7 @@
     <h5>Context data</h5>
     <p>This data is automatically appended by helyOS to the request data.</p>
     <p>
-      <i> {{ ' context:\{map,agents,dependencies\} ' }} </i>
+      <i> {{ ' context:\{map,agents,orchestration,dependencies\} ' }} </i>
     </p>
 
     <div>
@@ -127,7 +127,7 @@
 
       <div class="row">
         <fieldset class="form-group col-xl-12">
-          <label for="selectedItemDepsContext"> JSON Dependencies (responses from previous linked services) </label>
+          <label for="selectedItemDepsContext"> JSON Orchestration (current and next steps in the mission) and JSON Dependencies (responses from previous linked services) </label>
           <textarea
             id="selectedItemDepsContext"
             class="form-control"

--- a/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.ts
+++ b/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.ts
@@ -64,6 +64,7 @@ export class DispatchServicesComponent implements OnInit {
           'agents': context.agents,
         }, null, 3);
         this.selectedItemDepsContext = JSON.stringify({
+          'orchestration': context.orchestration,
           'dependencies': context.dependencies,
         }, null, 3);
       } catch (error) {


### PR DESCRIPTION
The text field that showed the context.dependencies field of sent service requests now shows the context.orchestration field as well. By this, the full request can be examined in the text fields.