### PR TITLE
add buttons in dashboard for download of service request and response json data

### DIFF
--- a/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.html
+++ b/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.html
@@ -53,6 +53,8 @@
           <th>Processed</th>
           <th>Fetched</th>
           <th>Status</th>
+          <th>Request</th>
+          <th>Response</th>
         </tr>
       </thead>
       <tbody>
@@ -73,6 +75,16 @@
           <td>{{ item.processed }}</td>
           <td>{{ item.fetched }}</td>
           <td>{{ item.status }}</td>
+          <td>
+            <button (click)="downloadRequest(item.id)" class="btn btn-outline-secondary btn-sm">
+              <i class="fas fa-download"></i> 
+            </button>
+          </td>
+          <td>
+            <button (click)="downloadResponse(item.id)" class="btn btn-outline-secondary btn-sm">
+              <i class="fas fa-download"></i> 
+            </button>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.ts
+++ b/helyos_dashboard/src/app/layout/dispatch-services/dispatch-services.component.ts
@@ -90,4 +90,39 @@ export class DispatchServicesComponent implements OnInit {
     return `${Math.round((d1.getTime() - d2.getTime()) / 1000)} secs`;
   }
 
+  private async downloadItem(itemId: string, type: 'request' | 'response') {
+    try {
+      const r = await this.helyosService.methods.servciceRequests.get(itemId);
+      this.selectedItem = r;
+  
+      const data = type === 'request' 
+        ? {
+            request: JSON.parse(this.selectedItem.request),
+            context: JSON.parse(this.selectedItem.context),
+            config: JSON.parse(this.selectedItem.config),
+          }
+        : JSON.parse(this.selectedItem.response);
+  
+      const json = JSON.stringify(data, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `service_${type}_${this.selectedItem.id}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Error downloading item:', error);
+    }
+  }
+  
+  downloadRequest(itemId: string) {
+    this.downloadItem(itemId, 'request');
+  }
+  
+  downloadResponse(itemId: string) {
+    this.downloadItem(itemId, 'response');
+  }
 }


### PR DESCRIPTION
This pull request adds buttons to the helyOS dashboard for downloading the full JSON data of service requests and responses. This feature enhances data accessibility and improves debugging capabilities.