### PR TITLE
skip service requests in the mission recipe pipeline if any depending previous service request was skipped

### DIFF
--- a/tests/17-assignment-microservice-orchestration.test.js
+++ b/tests/17-assignment-microservice-orchestration.test.js
@@ -38,14 +38,19 @@ describe('17 Test microservice switching and dispatch after assignment',   () =>
     });
 
 
+    it(' Microservice B2 is skipped', async () => {
+        const result =  await helyosApplication.waitMicroserviceStatus(2, 'skipped');
+        expect(result).toEqual('skipped');
+    });
+
     it(' Microservice B is ready', async () => {
-        const result =  await helyosApplication.waitMicroserviceStatus(2, 'ready');
+        const result =  await helyosApplication.waitMicroserviceStatus(3, 'ready');
         expect(result).toEqual('ready');
     });
 
 
-    it(' Microservice B2 is skipped', async () => {
-        const result =  await helyosApplication.waitMicroserviceStatus(3, 'skipped');
+    it(' Microservice C is skipped', async () => {
+        const result =  await helyosApplication.waitMicroserviceStatus(4, 'skipped');
         expect(result).toEqual('skipped');
     });
 

--- a/tests/settings/config/missions.yml
+++ b/tests/settings/config/missions.yml
@@ -131,6 +131,14 @@ missions:
           service_config: "{}"
 
 
+        - step: "B_SKIPPED"
+          service_type: "map"
+          request_order: 2
+          apply_result: false
+          service_config: "{}"
+          dependencies: '["A"]'
+
+
         - step: "B"
           service_type: "drive"
           request_order: 2
@@ -139,13 +147,12 @@ missions:
           dependencies: '["A"]'
 
 
-
-        - step: "B_SKIPPED"
-          service_type: "map"
+        - step: "C_SKIPPED"
+          service_type: "drive"
           request_order: 3
           apply_result: true
           service_config: "{}"
-          dependencies: '["A"]'
+          dependencies: '["B_SKIPPED"]'
 
 
 


### PR DESCRIPTION
Currently, if a service has a list of dependent steps (service requests) that must be called prior, and any of these prior services is skipped, the subsequent service will be stuck in the 'WAIT_DEPENDENCIES' state forever, as the previous service is skipped and never reaches the 'READY' status. 

This pull request implements the behavior, that if any of the previous steps is skipped, any following step will be skipped as well. 

This procedure enables the realization of disjunct paths in the mission recipe e.g.:

<img src="https://github.com/user-attachments/assets/0204e06b-646f-4427-93b2-294d939dc4ca" width="500">

The service in step A decides to take the upper path along Step B and C and consequently denotes Step B as only allowed next step . Step D is skipped because its required step A does not include Step D in the allowed next steps. As a consequence, Step E is skipped as well instead of being stuck in the wait_dependencies state. 
            