### PR TITLE
settings of existing microservices are not overwritten by microservices.yml by default

### DIFF
--- a/helyos_server/src/modules/read_config_yml.ts
+++ b/helyos_server/src/modules/read_config_yml.ts
@@ -6,6 +6,7 @@ import * as DatabaseService from '../services/database/database_services';
 import { logData } from './systemlog';
 import {lookup} from './utils';
 
+const OVERWRITE_MICROSERVICES = false
 const OVERWRITE_MISSIONS = false
 
 
@@ -30,7 +31,7 @@ export const registerManyMicroservices = async (servicesYmlPath) => {
                 const oldServices = await databaseServices.services.select({ name: service['name'] });
                 if (oldServices.length === 0) {
                     await databaseServices.services.insert(service);
-                } else {
+                } else if (OVERWRITE_MICROSERVICES) {
                     const servId = oldServices[0].id;
                     await databaseServices.services.update_byId(servId, service);
                 }


### PR DESCRIPTION
This pull requests makes the handling of the missions.yml and microservices.yml consistent: By default, new non-existing entries for missions and microservices are added to the database. The settings for existing entries in the database stay unchanged -> the settings in the yaml files for existing entries are ignored. 