### PR TITLE
feat: Add new DL Exchange to send/stream non-persistent data to agents

### DIFF
--- a/helyos_server/src/config.ts
+++ b/helyos_server/src/config.ts
@@ -112,6 +112,7 @@ const AGENT_MISSION_QUEUE = process.env.AGENT_MISSION_QUEUE || 'agent_mission_qu
 const SUMMARY_REQUESTS_QUEUE = 'agent_data_requests';
 const AGENTS_UL_EXCHANGE = process.env.AGENTS_UL_EXCHANGE || 'xchange_helyos.agents.ul';
 const AGENTS_DL_EXCHANGE = process.env.AGENTS_DL_EXCHANGE || 'xchange_helyos.agents.dl';
+const AGENTS_STREAM_DL_EXCHANGE = process.env.AGENTS_STREAM_DL_EXCHANGE || 'xchange_helyos.agents.stream.dl';
 const ANONYMOUS_EXCHANGE = process.env.ANONYMOUS_EXCHANGE || 'xchange_helyos.agents.anonymous';
 const AGENTS_MQTT_EXCHANGE = process.env.AGENTS_MQTT_EXCHANGE || 'xchange_helyos.agents.mqtt'; //amq.topic' 
 
@@ -179,6 +180,7 @@ export default  {
     SUMMARY_REQUESTS_QUEUE,
     AGENTS_UL_EXCHANGE,
     AGENTS_DL_EXCHANGE,
+    AGENTS_STREAM_DL_EXCHANGE,
     ANONYMOUS_EXCHANGE,
     AGENTS_MQTT_EXCHANGE, 
 

--- a/helyos_server/src/graphql/plugins/send_agent_stream_message.ts
+++ b/helyos_server/src/graphql/plugins/send_agent_stream_message.ts
@@ -1,0 +1,40 @@
+import { gql, makeExtendSchemaPlugin } from "postgraphile";
+import agentCommunication from "../../modules/communication/agent_communication";
+
+export default makeExtendSchemaPlugin(() => {
+    return {
+        typeDefs: gql`
+            input SendAgentStreamMessageInput {
+                clientMutationId: String
+                agentId: Int!
+                body: String!
+                metadata: JSON
+            }
+
+            type SendAgentStreamMessagePayload {
+                clientMutationId: String
+                success: Boolean!
+            }
+
+            extend type Mutation {
+                sendAgentStreamMessage(
+                input: SendAgentStreamMessageInput!
+                ): SendAgentStreamMessagePayload
+            }
+        `,
+        resolvers: {
+            Mutation: {
+                sendAgentStreamMessage: async (_query, args, _context, _resolveInfo) => {
+                    const { clientMutationId, agentId, body } = args.input;
+
+                    await agentCommunication.sendStreamMsgToAgent(agentId, body);
+
+                    return {
+                        clientMutationId,
+                        success: true,
+                    };
+                },
+            },
+        },
+    };
+});

--- a/helyos_server/src/index.ts
+++ b/helyos_server/src/index.ts
@@ -116,6 +116,7 @@ async function connectToRabbitMQ() {
 // 4) GraphQL server setup -  External App <-> Nodejs(GraphQL Lib) <-> Postgres
 // ----------------------------------------------------------------------------
 import { postgraphile, PostGraphileOptions } from "postgraphile";
+import sendAgentStreamMessagePlugin from './graphql/plugins/send_agent_stream_message';
 
 
 const pathPrefix = SERVER_PATH_BASE ? `/${SERVER_PATH_BASE}` : ''; 
@@ -132,6 +133,7 @@ const postGraphileOptions: PostGraphileOptions = {
     disableQueryLog: true,
     graphqlRoute: `${pathPrefix}/graphql`, 
     graphiqlRoute: `${pathPrefix}/graphiql`,
+    appendPlugins: [sendAgentStreamMessagePlugin],
     // showErrorStack: "json",
     // dynamicJson: true,
     // ignoreRBAC: false,

--- a/helyos_server/src/modules/communication/agent_communication.ts
+++ b/helyos_server/src/modules/communication/agent_communication.ts
@@ -181,6 +181,20 @@ async function sendReduceMsgRateInstantAction(agent: Agent, commandStr: string):
     await sendEncryptedMsgToAgent(agent.id, JSON.stringify(assignmentObj), 'instantActions');
 }
 
+async function sendStreamMsgToAgent(agentId: number, payload: string): Promise<void> {
+    const databaseServices = await DatabaseService.getInstance(); 
+    const uuids = await databaseServices.agents.getUuids([agentId]);
+
+    const assignmentObj = {
+        uuid: uuids[0],
+        metadata: {},
+        body: payload,
+        _version: MESSAGE_VERSION,
+    };
+
+    await sendEncryptedMsgToAgent(agentId, JSON.stringify(assignmentObj), 'stream');
+}
+
 
 
 /**
@@ -351,6 +365,10 @@ async function sendEncryptedMsgToAgent(agentId: number, message: string, reason:
             case 'order':
                 routingKey = `agent.${agent.uuid}.order`;
                 break;
+            case 'stream':
+                exchange = rabbitMQServices.AGENTS_STREAM_DL_EXCHANGE;
+                routingKey = `agent.${agent.uuid}.stream`;
+                break;
             case 'instantActions':
             case 'reserve':
             case 'release':
@@ -375,6 +393,7 @@ export default {
     waitAgentStatusForWorkProcess,
     sendReleaseFromWorkProcessRequest,
     sendCustomInstantActionToAgent,
+    sendStreamMsgToAgent,
     sendAssignmentToExecuteInAgent,
     cancelAssignmentInAgent
   };

--- a/helyos_server/src/modules/communication/agent_communication.ts
+++ b/helyos_server/src/modules/communication/agent_communication.ts
@@ -353,6 +353,10 @@ async function sendEncryptedMsgToAgent(agentId: number, message: string, reason:
 
         let exchange = rabbitMQServices.AGENTS_DL_EXCHANGE;
 
+        if (reason === 'stream') {
+            exchange = rabbitMQServices.AGENTS_STREAM_DL_EXCHANGE;
+        }
+
         if (agent.protocol === 'MQTT') {
             exchange = rabbitMQServices.AGENTS_MQTT_EXCHANGE;
         }
@@ -366,7 +370,6 @@ async function sendEncryptedMsgToAgent(agentId: number, message: string, reason:
                 routingKey = `agent.${agent.uuid}.order`;
                 break;
             case 'stream':
-                exchange = rabbitMQServices.AGENTS_STREAM_DL_EXCHANGE;
                 routingKey = `agent.${agent.uuid}.stream`;
                 break;
             case 'instantActions':

--- a/helyos_server/src/rbmq_topology.ts
+++ b/helyos_server/src/rbmq_topology.ts
@@ -6,7 +6,8 @@ import { logData } from './modules/systemlog';
 const { PREFETCH_COUNT, TTL_VISUAL_MSG, TTL_STATE_MSG } = config;
 
 const { AGENTS_UL_EXCHANGE, AGENTS_DL_EXCHANGE, 
-        ANONYMOUS_EXCHANGE, AGENTS_MQTT_EXCHANGE } = config;
+        AGENTS_STREAM_DL_EXCHANGE, ANONYMOUS_EXCHANGE, 
+        AGENTS_MQTT_EXCHANGE } = config;
 
 const { CHECK_IN_QUEUE, AGENT_MISSION_QUEUE, 
         AGENT_VISUALIZATION_QUEUE, AGENT_UPDATE_QUEUE,
@@ -30,6 +31,9 @@ async function configureRabbitMQSchema(dataChannels: DataChannel[]): Promise<Dat
     await mainChannel.assertExchange(ANONYMOUS_EXCHANGE, 'topic', { durable: true });
     await rbmqServices.assertOrSubstituteQueue(mainChannel, CHECK_IN_QUEUE, false, true);
     await mainChannel.bindQueue(CHECK_IN_QUEUE, ANONYMOUS_EXCHANGE, "*.*.checkin");
+
+    // SET EXCHANGE "STREAM DOWN LINK (Stream DL) TO STREAM MESSAGES TO AGENT"
+    await mainChannel.assertExchange(AGENTS_STREAM_DL_EXCHANGE, 'topic', { durable: true })
 
     // SET EXCHANGE "DOWN LINK" (DL) TO SEND MESSAGES TO AGENT 
     await mainChannel.assertExchange(AGENTS_DL_EXCHANGE, 'topic', { durable: true });

--- a/helyos_server/src/services/message_broker/rabbitMQ_services.ts
+++ b/helyos_server/src/services/message_broker/rabbitMQ_services.ts
@@ -255,7 +255,7 @@ function createDebugQueues(agent: any) {
         dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_MQTT_EXCHANGE, `*.${agent.uuid}.instantActions`);
         dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_DL_EXCHANGE, `*.${agent.uuid}.instantActions`);
 
-        dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_MQTT_EXCHANGE, `*.${agent.uuid}.stream`); // TODO: maybe remove?
+        dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_MQTT_EXCHANGE, `*.${agent.uuid}.stream`);
         dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_STREAM_DL_EXCHANGE, `*.${agent.uuid}.stream`);
     });
 }

--- a/helyos_server/src/services/message_broker/rabbitMQ_services.ts
+++ b/helyos_server/src/services/message_broker/rabbitMQ_services.ts
@@ -33,6 +33,7 @@ const {
     SUMMARY_REQUESTS_QUEUE,
     AGENTS_UL_EXCHANGE,
     AGENTS_DL_EXCHANGE,
+    AGENTS_STREAM_DL_EXCHANGE,
     AGENTS_MQTT_EXCHANGE,
     ENCRYPT,
 } = config;
@@ -253,6 +254,9 @@ function createDebugQueues(agent: any) {
         dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_DL_EXCHANGE, `*.${agent.uuid}.assignment`);
         dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_MQTT_EXCHANGE, `*.${agent.uuid}.instantActions`);
         dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_DL_EXCHANGE, `*.${agent.uuid}.instantActions`);
+
+        dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_MQTT_EXCHANGE, `*.${agent.uuid}.stream`); // TODO: maybe remove?
+        dataChannel.bindQueue(`tap-cmd_to_${agent.name}`, AGENTS_STREAM_DL_EXCHANGE, `*.${agent.uuid}.stream`);
     });
 }
 
@@ -321,6 +325,7 @@ export default {
     YARD_VISUALIZATION_QUEUE,
     AGENTS_UL_EXCHANGE,
     AGENTS_DL_EXCHANGE,
+    AGENTS_STREAM_DL_EXCHANGE,
     ANONYMOUS_EXCHANGE,
     AGENTS_MQTT_EXCHANGE,
     RBMQ_VHOST,


### PR DESCRIPTION
This feature was added to enable sending frequent non-persistent data to Agents, this is useful when you dont want HelyOS to log every single message you send through it.